### PR TITLE
fixed #1 - Options, features and callbacks are not initialized if set to 'false'

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -293,7 +293,7 @@ class DataTable extends Widget
         ];
         $result = [];
         foreach ($features as $attribute) {
-            if (!empty($this->$attribute)) {
+            if ($this->$attribute !== null) {
                 $result[$attribute] = $this->$attribute;
             }
         }
@@ -327,7 +327,7 @@ class DataTable extends Widget
         ];
         $result = [];
         foreach ($options as $attribute) {
-            if (!empty($this->$attribute)) {
+            if ($this->$attribute !== null) {
                 $result[$attribute] = $this->$attribute;
             }
         }
@@ -354,7 +354,7 @@ class DataTable extends Widget
         ];
         $results = [];
         foreach ($callbacks as $attribute) {
-            if (!empty($this->$attribute)) {
+            if ($this->$attribute !== null) {
                 $results[$attribute] = new JsExpression($this->$attribute);
             }
         }
@@ -382,4 +382,4 @@ class DataTable extends Widget
         }
     }
 
-} 
+}


### PR DESCRIPTION
!empty(... called on attributes was skipping/omitting all those options/features (and potentially callbacks, you never know) that was explicitly set to false.
