### PR TITLE
Update Readme to explain difference id

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ To pass them as widget options:
     ]) ?>
 ```
 
+## Specifies datatable id
+
+```php
+<?= \nullref\datatable\DataTable::widget([
+    'data' => $dataProvider->getModels(),
+    'id' => 'your-datatable-id'
+]) ?>
+```
+
 ## Add Links to row
 
 ```php


### PR DESCRIPTION
I have a problem when create datatable without id. Datatable id also used in bootstrap4 accordion item in Yii2. And from code, I've found you can assign different datatable id, but It is not explain enough in readme.