### PR TITLE
add bootstrap4/5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.13",
         "bower-asset/datatables": "~1.10.15",
-        "bower-asset/datatables.net-bs4": "~1.10.15"
+        "bower-asset/datatables.net-bs4": "~1.10.15",
+        "npm-asset/datatables.net-bs5": "~1.10.15"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.13",
         "bower-asset/datatables": "~1.10.15",
-        "bower-asset/datatables-plugins": "~1.10.15"
+        "bower-asset/datatables.net-bs4": "~1.10.15"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.13",
         "bower-asset/datatables": "~1.10.15",
+        "bower-asset/datatables-plugins": "~1.10.15",
         "bower-asset/datatables.net-bs4": "~1.10.15",
         "npm-asset/datatables.net-bs5": "~1.10.15"
     },

--- a/src/assets/DataTableBootstrapAsset.php
+++ b/src/assets/DataTableBootstrapAsset.php
@@ -33,7 +33,7 @@ class DataTableBootstrapAsset extends AssetBundle
             $this->js[] = 'js\dataTables.bootstrap4' . (YII_ENV_DEV ? '' : '.min') . '.js';
 
         } else {
-            $this->sourcePath = '@bower/datatables.net-bs5';
+            $this->sourcePath = '@npm/datatables.net-bs5';
             $this->depends[] = 'yii\bootstrap5\BootstrapAsset';
             $this->css[] = 'css\dataTables.bootstrap5.css';
             $this->js[] = 'js\dataTables.bootstrap5' . (YII_ENV_DEV ? '' : '.min') . '.js';

--- a/src/assets/DataTableBootstrapAsset.php
+++ b/src/assets/DataTableBootstrapAsset.php
@@ -12,9 +12,6 @@ use yii\web\AssetBundle;
 
 class DataTableBootstrapAsset extends AssetBundle
 {
-    # public $sourcePath = '@bower/datatables-plugins/integration/bootstrap/3';
-    public $sourcePath = '@bower/datatables.net-bs4';
-
     public $depends = [
         DataTableBaseAsset::class,
     ];
@@ -23,10 +20,24 @@ class DataTableBootstrapAsset extends AssetBundle
     {
         parent::init();
 
-        #$this->depends[] = 'yii\bootstrap\BootstrapAsset';
-        $this->css[] = 'dataTables.bootstrap.css';
-        $this->js[] = 'dataTables.bootstrap' . (YII_ENV_DEV ? '' : '.min') . '.js';
-        $this->depends[] = 'yii\bootstrap4\BootstrapAsset';
+        if (class_exists('yii\bootstrap\BootstrapAsset')) {
+            $this->sourcePath = '@bower/datatables-plugins/integration/bootstrap/3';
+            $this->depends[] = 'yii\bootstrap\BootstrapAsset';
+            $this->css[] = 'dataTables.bootstrap.css';
+            $this->js[] = 'dataTables.bootstrap' . (YII_ENV_DEV ? '' : '.min') . '.js';
+
+        } else if(class_exists('yii\bootstrap4\BootstrapAsset')) {
+            $this->sourcePath = '@bower/datatables.net-bs4';
+            $this->depends[] = 'yii\bootstrap4\BootstrapAsset';
+            $this->css[] = 'css\dataTables.bootstrap4.css';
+            $this->js[] = 'js\dataTables.bootstrap4' . (YII_ENV_DEV ? '' : '.min') . '.js';
+
+        } else {
+            $this->sourcePath = '@bower/datatables.net-bs5';
+            $this->depends[] = 'yii\bootstrap5\BootstrapAsset';
+            $this->css[] = 'css\dataTables.bootstrap5.css';
+            $this->js[] = 'js\dataTables.bootstrap5' . (YII_ENV_DEV ? '' : '.min') . '.js';
+        }
     }
 
 } 

--- a/src/assets/DataTableBootstrapAsset.php
+++ b/src/assets/DataTableBootstrapAsset.php
@@ -22,9 +22,10 @@ class DataTableBootstrapAsset extends AssetBundle
     {
         parent::init();
 
-        $this->depends[] = 'yii\bootstrap\BootstrapAsset';
+        #$this->depends[] = 'yii\bootstrap\BootstrapAsset';
         $this->css[] = 'dataTables.bootstrap.css';
         $this->js[] = 'dataTables.bootstrap' . (YII_ENV_DEV ? '' : '.min') . '.js';
+        $this->depends[] = 'yii\bootstrap4\BootstrapAsset';
     }
 
 } 

--- a/src/assets/DataTableBootstrapAsset.php
+++ b/src/assets/DataTableBootstrapAsset.php
@@ -12,7 +12,8 @@ use yii\web\AssetBundle;
 
 class DataTableBootstrapAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/datatables-plugins/integration/bootstrap/3';
+    # public $sourcePath = '@bower/datatables-plugins/integration/bootstrap/3';
+    public $sourcePath = '@bower/datatables.net-bs4';
 
     public $depends = [
         DataTableBaseAsset::class,


### PR DESCRIPTION
This PR Closes #66 and adds support for bootstrap4 (and bootstrap5).

The code is still compatibel with older bootstrap3 versions of yii, the assest class not checks wich bootstrap version exists in yii and chooses the matching assets.

For bootstrap5 I could not find the bower assets (in [asset-packagist](https://asset-packagist.org/package/search?query=datatables.net-bs5&platform=bower%2Cnpm) ), so I took the npm assets. I think that is no problem.