### PR TITLE
Fix passing custom parameters to dataTables column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - if set, property `data` is auto filled with models from dataProvider
   - if models are found either in `dataProvider` or in `data`, column labels are loaded from
     `Model::attributes()`
+- restore support for custom column definitions (#52)
 
 ## v1.1.1
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,12 @@
         {
             "name": "Dmytro Karpovych",
             "email": "ZAYEC77@gmail.com"
+        },
+        {
+            "name": "Radon8472",
+            "email": "develop@radon-software.net",
+            "homepage": "https://github.com/Radon8472",
+            "role": "Contributor"
         }
     ],
     "minimum-stability": "stable",

--- a/src/DataTableColumn.php
+++ b/src/DataTableColumn.php
@@ -7,13 +7,34 @@
 
 namespace nullref\datatable;
 
+use yii\base\Arrayable;
 use yii\base\InvalidConfigException;
 use yii\base\Widget;
 use yii\helpers\Html;
 use yii\helpers\Inflector;
 use yii\web\JsExpression;
 
-class DataTableColumn extends Widget
+/**
+ * Class DataTableColumn
+ *
+ * @package nullref\datatable
+ *
+ * Features
+ *
+ * @property string $type possible values (num, num-fmt, html-num, html-num-fmt, html, string)
+ * @property bool   $orderable Using this parameter, you can remove the end user's ability to order upon a column.
+ * @property bool   $searchable Using this parameter, you can define if DataTables should include this column in the filterable data in the table
+ * @property bool   $visible show and hide columns dynamically through use of this option
+ * @property string $width This parameter can be used to define the width of a column, and may take any CSS value (3em, 20px etc).
+ * @property string $cellType Change the cell type created for the column - either TD cells or TH cells
+ * @property string $contentPadding Add padding to the text content used when calculating the optimal width for a table.
+ * @property string $orderDataType
+ *
+ * Check the full list of supported properties
+ *
+ * @see: https://datatables.net/reference/option/columns
+ */
+class DataTableColumn extends Widget implements Arrayable
 {
     /**
      * @var string the attribute name associated with this column.
@@ -67,6 +88,8 @@ class DataTableColumn extends Widget
      * - If you don't want a filter for this data column, set this value to be false.
      */
     protected $filter;
+
+    private $_options = [];
 
     /**
      * Check if all required properties is set
@@ -197,4 +220,44 @@ class DataTableColumn extends Widget
         return $this->extraColumns;
     }
 
+    public function __get($name)
+    {
+        return $this->canGetProperty($name, true)
+            ? parent::__get($name)
+            : (isset($this->_options[$name]) ? $this->_options[$name] : null);
+    }
+
+    public function __set($name, $value)
+    {
+        if ($this->canSetProperty($name, true))
+            return parent::__set($name, $value);
+        else
+            return $this->_options[$name] = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fields()
+    {
+        return \Yii::getObjectVars($this);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function extraFields()
+    {
+        return $this->_options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(array $fields = [], array $expand = [], $recursive = true)
+    {
+         return $recursive
+            ? array_merge_recursive($this->fields(), $this->extraFields())
+            : array_merge($this->fields(), $this->extraFields());
+    }
 }


### PR DESCRIPTION
This add ability to pass all datatables custom properties into class DataTableColumn using the ArrayAccess technic.

Maybe even some of the currently public defined properies (e.g. `render`) could be removed now.

For this case I did not use the `ArrayableTrait`, and implemented the basic functionalitity directly in DataTableColumn.


Fixes #52