### PR TITLE
Fix: Replace deprecated ${var} string interpolation syntax with {$var}

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -248,11 +248,11 @@ class DataTable extends Widget
             $this->getView()->registerJs(
                 <<<JS
 (function() {
-    var params = ${encodedParams};
+    var params = {$encodedParams};
     var table;
-    ${globalVariable} table = jQuery("#${id}").DataTable(params);
+    {$globalVariable} table = jQuery("#{$id}").DataTable(params);
     var filterRow = jQuery('<tr></tr>');
-    jQuery('#${id} thead tr th').each(function(i) 
+    jQuery('#{$id} thead tr th').each(function(i) 
     {
         var cell = jQuery('<td></td>')
             .attr('colspan', jQuery(this).attr('colspan'))
@@ -266,8 +266,8 @@ class DataTable extends Widget
             cell.html(jQuery.isFunction(params.columns[i].renderFilter) ? params.columns[i].renderFilter(table) : params.columns[i].renderFilter);
         }
     });
-    jQuery('#${id} thead').append(filterRow);
-    jQuery('#${id} thead tr:eq(1) td').each( function (i) 
+    jQuery('#{$id} thead').append(filterRow);
+    jQuery('#{$id} thead tr:eq(1) td').each( function (i) 
     {
         jQuery(':input', this).on('keyup change', function () {
             if (table.column(i).search() !== jQuery(this).val()) {


### PR DESCRIPTION
## 🐛 **Bug Fix: PHP String Interpolation Deprecation Warning**

### **Issue**
Fixes PHP deprecation warning: `Using ${var} in strings is deprecated, use {$var} instead`

### **Changes**
- Replaced all instances of deprecated `${var}` syntax with recommended `{$var}` syntax
- Updated heredoc JavaScript block in `DataTable.php` 
- Fixed 6 instances of deprecated string interpolation

### **Files Changed**
- `src/DataTable.php` - Updated JavaScript heredoc block with column filtering logic

### **Compatibility**
- ✅ **PHP 8.0+**: Removes deprecation warnings
- ✅ **Backward Compatible**: `{$var}` syntax works in all supported PHP versions (>=7.4)
- ✅ **Functionality**: No behavior changes, only syntax update

### **Testing**
- [x] Verified no more `${var}` patterns exist in codebase
- [x] Confirmed all variables are properly interpolated with `{$var}` syntax
- [x] No functionality changes - only syntax modernization

**Fixes deprecation warnings reported in GitHub issues.**